### PR TITLE
remove sparseqr dependency

### DIFF
--- a/DiffusionEMD/diffusion_emd.py
+++ b/DiffusionEMD/diffusion_emd.py
@@ -5,8 +5,9 @@ corresponds to the Wasserstein distance between distributions.
 
 import numpy as np
 import pygsp
+import scipy
 from scipy.linalg import qr
-from scipy.linalg.interpolative import interp_dcomp
+#from scipy.linalg.interpolative import interp_decomp
 import scipy.sparse
 
 from . import estimate_utils

--- a/DiffusionEMD/diffusion_emd.py
+++ b/DiffusionEMD/diffusion_emd.py
@@ -6,8 +6,8 @@ corresponds to the Wasserstein distance between distributions.
 import numpy as np
 import pygsp
 from scipy.linalg import qr
+from scipy.linalg.interpolative import interp_dcomp
 import scipy.sparse
-import sparseqr
 
 from . import estimate_utils
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy
 matplotlib>=3.0
 pot
 pygsp
+graphtools

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,4 @@ numpy>=1.16.0
 scipy
 matplotlib>=3.0
 pot
-sparseqr
 pygsp
-

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ install_requires = [
     "matplotlib>=3.0",
     "pot",
     "pygsp",
+    "graphtools",
 ]
 
 doc_requires = [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ install_requires = [
     "scipy",
     "matplotlib>=3.0",
     "pot",
-    "sparseqr",
     "pygsp",
 ]
 
@@ -53,4 +52,3 @@ setup(
     long_description=readme,
     url="https://github.com/KrishnaswamyLab/DiffusionEMD",
 )
-


### PR DESCRIPTION
sparseqr has trouble building (see #1 #2), and in the repository's current state it doesn't seem to be used (i.e. code related to this is commented out) 
https://github.com/KrishnaswamyLab/DiffusionEMD/blob/d716d4c2ccb9ede6b92331ebdcec39202ff0f117/DiffusionEMD/diffusion_emd.py#L127-L129