### PR TITLE
Update scikit-learn imports

### DIFF
--- a/DiffusionEMD/metric_tree.py
+++ b/DiffusionEMD/metric_tree.py
@@ -10,7 +10,8 @@ adding points after the initial construction.
 import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_X_y, check_is_fitted
-from sklearn.neighbors import KDTree, BallTree, DistanceMetric
+from sklearn.neighbors import KDTree, BallTree
+from sklearn.metrics import DistanceMetric
 from sklearn.cluster import MiniBatchKMeans
 from scipy.sparse import coo_matrix
 


### PR DESCRIPTION
Hi,
I want to use your interesting approach in the package but the last scikit learn version which supported
`from sklearn.neighbors import DistanceMetric` is according to the docs officially 0.24. (from 2021-22)
DistanceMetric has to instead be imported from sklearn.metrics

With regards to reproducibility of notebooks:

after making these changes in this [commit](https://github.com/KrishnaswamyLab/DiffusionEMD/commit/da62a3a29e4f1640d77ceec7531c2de262ed0650) I could reproduce the _Swissroll Example.ipynb_ notebook but not the _Line Example.ipynb_.

and got following error:
<img width="1486" alt="Screenshot 2024-09-03 at 13 32 13" src="https://github.com/user-attachments/assets/d1ca41aa-76dc-42fb-8aa3-a360070fef74">


There because of old implementation of **pygsp**, in [line](https://github.com/epfl-lts2/pygsp/blob/a3412ce7696c02c8a55439e89d0c9ab8ae863269/pygsp/graphs/nngraphs/nngraph.py#L151) causes the **scipy** to throw this [line](https://github.com/scipy/scipy/blob/92d2a8592782ee19a1161d0bf3fc2241ba78bb63/scipy/spatial/_kdtree.py#L472)

as a workaround in this [commit](https://github.com/KrishnaswamyLab/DiffusionEMD/commit/76c446eefaae43f8b69bd5d2d94a12a40a0dd762)
I used sklrean to create a radius-based nearest neighbors graph that I believe matches what pygsp.graphs.NNGraph construct to avoid said issue 

I wrapped the created graph with pygsp instance so it doesnt break the usage in the notebooks or in case someone using the dataset class

the produced outputs after these changes are very similar to what you have in the repository 

if these changes aligens with what you meant to create with Line Dataset, it would greatly help me if you accept this PR.
